### PR TITLE
add two Nextflow examples

### DIFF
--- a/Nextflow/run-blast-example.sh
+++ b/Nextflow/run-blast-example.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if [[ $EESSI_CVMFS_REPO == "/cvmfs/software.eessi.io" ]] && [[ $EESSI_VERSION == "2023.06" ]]; then
+    module load Nextflow/23.10.0
+    module load BLAST+/2.14.1-gompi-2023a
+else
+    echo "Don't know which modules to load for ${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}" >&2
+    exit 1
+fi
+
+time nextflow run blast-example

--- a/Nextflow/run-ml-hyperopt.sh
+++ b/Nextflow/run-ml-hyperopt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+if [[ $EESSI_CVMFS_REPO == "/cvmfs/software.eessi.io" ]] && [[ $EESSI_VERSION == "2023.06" ]]; then
+    module load Nextflow/23.10.0
+    module load scikit-learn/1.4.0-gfbf-2023b
+    module load matplotlib/3.8.2-gfbf-2023b
+else
+    echo "Don't know which modules to load for ${EESSI_CVMFS_REPO}/versions/${EESSI_VERSION}" >&2
+    exit 1
+fi
+
+time nextflow run ml-hyperopt


### PR DESCRIPTION
These scripts run the examples from https://www.nextflow.io/blast-pipeline.html and https://www.nextflow.io/machine-learning-pipeline.html.

```
$ ./run-ml-hyperopt.sh
Nextflow 24.10.6 is available - Please consider updating your version to it
N E X T F L O W  ~  version 23.10.0
Pulling nextflow-io/ml-hyperopt ...
 downloaded from https://github.com/nextflow-io/hyperopt.git
Launching `https://github.com/nextflow-io/ml-hyperopt` [drunk_goodall] DSL2 - revision: 66f4ceb69d [master]

    M L - H Y P E R O P T   P I P E L I N E
    =======================================
    fetch_dataset   : true
    dataset_name    : wdbc

    visualize       : true

    train           : true
    train_data      : data/*.train.txt
    train_meta      : data/*.meta.json
    train_models    : [dummy, gb, lr, mlp, rf]

    predict         : true
    predict_models  : data/*.pkl
    predict_data    : data/*.predict.txt
    predict_meta    : data/*.meta.json

    outdir          : results
    
executor >  local (14)
[3c/6e20c7] process > fetch_dataset (wdbc)    [100%] 1 of 1 ✔
[b9/96611b] process > split_train_test (wdbc) [100%] 1 of 1 ✔
[41/32997c] process > visualize (1)           [100%] 2 of 2 ✔
[86/d316b7] process > train (wdbc/mlp)        [100%] 5 of 5 ✔
[05/07bab9] process > predict (wdbc/mlp)      [100%] 5 of 5 ✔
The best model for 'wdbc' was 'rf', with accuracy = 0.991

Done!
WARN: Training is enabled but pre-trained model(s) are also provided, pre-trained models will be ignored


real	0m40,548s
user	2m59,848s
sys	0m15,717s
```

```
$ ./run-blast-example.sh 
Nextflow 24.10.6 is available - Please consider updating your version to it
N E X T F L O W  ~  version 23.10.0
Pulling nextflow-io/blast-example ...
 downloaded from https://github.com/nextflow-io/blast-example.git
Launching `https://github.com/nextflow-io/blast-example` [backstabbing_cajal] DSL2 - revision: c7e4282e26 [master]
executor >  local (2)
[a4/eb5865] process > blast (1)   [100%] 1 of 1 ✔
[a3/e736aa] process > extract (1) [100%] 1 of 1 ✔
matching sequences:
 >1ABO:B 
MNDPNLFVALYDFVASGDNTLSITKGEKLRVLGYNHNGEWCEAQTKNGQGWVPSNYITPVNS
>1ABO:A 
MNDPNLFVALYDFVASGDNTLSITKGEKLRVLGYNHNGEWCEAQTKNGQGWVPSNYITPVNS
>1YCS:B 
PEITGQVSLPPGKRTNLRKTGSERIAHGMRVKFNPLPLALLLDSSLEGEFDLVQRIIYEVDDPSLPNDEGITALHNAVCA
GHTEIVKFLVQFGVNVNAADSDGWTPLHCAASCNNVQVCKFLVESGAAVFAMTYSDMQTAADKCEEMEEGYTQCSQFLYG
VQEKMGIMNKGVIYALWDYEPQNDDELPMKEGDCMTIIHREDEDEIEWWWARLNDKEGYVPRNLLGLYPRIKPRQRSLA
>1IHD:C 
LPNITILATGGTIAGGGDSATKSNYTVGKVGVENLVNAVPQLKDIANVKGEQVVNIGSQDMNDNVWLTLAKKINTDCDKT



real	0m8,464s
user	0m21,865s
sys	0m0,724s
```