### PR TITLE
Simplify script for installation of EESSI + use CDN by default

### DIFF
--- a/scripts/install_cvmfs_eessi.sh
+++ b/scripts/install_cvmfs_eessi.sh
@@ -32,34 +32,8 @@ error_msg="Don't know how to handle operating system ($NAME : $VERSION)"
 # Check whether we have a RHEL-like or Debian-like system
 if [[ "${ID_LIKE}" =~ "rhel" ]] || [[ "${ID_LIKE}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "centos" ]]
 then
-  # No working yum repo for Amazon Linux so need to treat that special case
-  if [[ $NAME == "Amazon Linux" ]]
-  then
-    if [[ $VERSION == "2" ]]
-    then
-      # Amazon Linux 2 maps to RHEL7 (roughly)
-      rhel_version="7"
-    elif [[ $VERSION == "2023" ]]
-    then
-      # This maps to RHEL9 (roughly)
-      rhel_version="9"
-    else
-      echo "$error_msg"
-      exit 1
-    fi
-    # Install CVMFS (without a yum repo for Amazon Linux), config file first, then CVMFS itself
-    AMAZON_LINUX_CVMFS_VERSION=2.11.5
-    AMAZON_LINUX_CVMFS_PACKAGE_VERSION=${AMAZON_LINUX_CVMFS_VERSION}-1
-    dry_run "yum install -y https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-config-default-latest.noarch.rpm"
-    dry_run "yum install -y https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs/EL/${rhel_version}/$(uname -m)/cvmfs-libs-${AMAZON_LINUX_CVMFS_PACKAGE_VERSION}.el${rhel_version}.$(uname -m).rpm"
-    dry_run "yum install -y https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs/EL/${rhel_version}/$(uname -m)/cvmfs-${AMAZON_LINUX_CVMFS_PACKAGE_VERSION}.el${rhel_version}.$(uname -m).rpm"
-  else
-    # Assume everything else is RHEL-like (install the yum repo and then cvmfs)
-    dry_run "yum install -y https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-release-latest.noarch.rpm"
-    dry_run "yum install -y cvmfs"
-  fi
-  # Install the EESSI configuration (not strictly necessary as software.eessi.io ships in the default)
-  dry_run "yum install -y https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi-latest.noarch.rpm"
+  dry_run "yum install -y https://cvmrepo.s3.cern.ch/cvmrepo/yum/cvmfs-release-latest.noarch.rpm"
+  dry_run "yum install -y cvmfs"
 elif [[ "${ID_LIKE}" =~ "debian" ]] || [[ "${ID}" =~ "debian" ]]
 then
   dry_run "apt-get update"
@@ -69,11 +43,6 @@ then
   dry_run "rm -f cvmfs-release-latest_all.deb"
   dry_run "apt-get update"
   dry_run "apt-get install -y cvmfs"
-
-  # Install the EESSI configuration (not strictly necessary as software.eessi.io ships in the default)
-  dry_run "wget https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb"
-  dry_run "dpkg -i cvmfs-config-eessi_latest_all.deb"
-  dry_run "rm -f cvmfs-config-eessi_latest_all.deb"
 else
   echo "$error_msg"
   exit 1
@@ -82,6 +51,8 @@ fi
 # Create a simple configuration
 dry_run "bash -c \"echo 'CVMFS_CLIENT_PROFILE=single' > /etc/cvmfs/default.local\""
 dry_run "bash -c \"echo 'CVMFS_QUOTA_LIMIT=10000' >> /etc/cvmfs/default.local\""
+# Use a CDN to control the load on the public mirrors of EESSI
+dry_run "bash -c \"echo 'CVMFS_USE_CDN=yes' >> /etc/cvmfs/default.local\""
 
 # Initialise cvmfs
 dry_run "cvmfs_config setup"


### PR DESCRIPTION
Packages for Amazon Linux are now shipped by CVMFS, so no need for the logic branch for that case.

Switch to using the default EESSI configuration package shipped with CVMFS so that we can use a CDN to provide EESSI. If people want better performance they'll need to dig a little deeper into the docs.